### PR TITLE
Fix headers, expand docs, add resource test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # PDF.js Viewer Project
 
-PDF viewer. 
-Proyecto y README.md aún en desarrollo.
+This project offers a minimal viewer for PDF files powered by [PDF.js](https://mozilla.github.io/pdf.js/).
+
+## Usage
+
+The HTML templates live in the `templates/` directory. Open `templates/index.html` in a web browser to start.
+
+An internet connection is required to load the PDF.js library from a CDN.
+
+## Running Tests
+
+Ensure you have Python 3 installed. From the project root run:
+
+```bash
+python -m unittest discover tests
+```
+
+

--- a/templates/ayuda.html
+++ b/templates/ayuda.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <header role="banner">
-    <h1>Visor documentos PDF</h1>
+    <h1>Visor de documentos PDF</h1>
     <p>¿Necesitas ayuda?</p>
     <nav>
       <ul>

--- a/templates/historial.html
+++ b/templates/historial.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <header role="banner">
-    <h1>Visor documentos PDF</h1>
+    <h1>Visor de documentos PDF</h1>
     <p>Historial de acceso a tu visor de PDF.</p>
     <nav>
       <ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <header role="banner">
-    <h1>Visor documentos PDF</h1>
+    <h1>Visor de documentos PDF</h1>
     <p>Visualiza y analiza tus documentos PDF de forma accesible.</p>
     <nav>
       <ul>

--- a/templates/visor.html
+++ b/templates/visor.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <header role="banner">
-    <h1>Visor documentos PDF</h1>
+    <h1>Visor de documentos PDF</h1>
     <p>Visualiza y analiza tus documentos PDF de forma accesible.</p>
     <nav>
       <ul>

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,41 @@
+import os
+import glob
+import unittest
+from html.parser import HTMLParser
+
+
+class AssetParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.assets = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == 'link' and 'href' in attrs:
+            self.assets.append(attrs['href'])
+        elif tag == 'script' and 'src' in attrs:
+            self.assets.append(attrs['src'])
+
+
+def collect_assets(html_path):
+    parser = AssetParser()
+    with open(html_path, 'r', encoding='utf-8') as f:
+        parser.feed(f.read())
+    return parser.assets
+
+
+class AssetTest(unittest.TestCase):
+    def test_local_assets_exist(self):
+        template_dir = os.path.join(os.path.dirname(__file__), '..', 'templates')
+        html_files = glob.glob(os.path.join(template_dir, '*.html'))
+        for html_file in html_files:
+            assets = collect_assets(html_file)
+            for asset in assets:
+                if asset.startswith('http://') or asset.startswith('https://'):
+                    continue
+                abs_path = os.path.normpath(os.path.join(os.path.dirname(html_file), asset))
+                self.assertTrue(os.path.isfile(abs_path), f'{html_file} references missing asset {asset}')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct Spanish wording in HTML headers
- document usage instructions in README
- add a simple test to validate asset links

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6847e42603e0833097ce57bc47b6c1d4